### PR TITLE
Add Dockerfile, foundry.lock, .toml for CI use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+################################################
+# 
+# `foundry-base` layer is where we build our own foundry container to use as a base image for
+# anything that needs to use forge/anvil/cast/etc. This uses thrackle-io/foundry to install
+# numbered versions of foundry's tools, using a modified `foundryup` and a foundry.lock file.
+# The Foundry tools are installed as precompiled binaries providing a fast build time.
+#
+# This layer is cached and not re-built unless there is a change to foundry.lock.
+################################################
+
+FROM rust:1.78.0-bookworm AS foundry-base
+
+RUN apt update
+RUN apt install -y curl unzip git make procps python3 python3-pip python3.11-venv jq gh npm
+
+WORKDIR /usr/local/foundry
+
+COPY foundry.lock .
+
+## Install Foundry via Thrackle's foundryup, using version set in foundry.lock (awk ignores comments)
+RUN curl -sSL https://raw.githubusercontent.com/thrackle-io/foundry/refs/heads/master/foundryup/foundryup -o /usr/local/bin/foundryup && \
+  chmod +x /usr/local/bin/foundryup && \
+  FOUNDRY_DIR=/usr/local foundryup --version $(awk '$1~/^[^#]/' foundry.lock)
+
+################################################
+#
+# `anvil` layer runs Anvil the local development chain from Foundry
+#
+# FOUNDRY_PROFILE selects a profile from foundry.toml
+# RUST_LOG configures anvil output information. I think. 
+# CHAIN_ID is the chain-id Anvil runs on
+#
+################################################
+
+FROM foundry-base AS anvil
+ENV FOUNDRY_PROFILE=docker
+ENV RUST_LOG=backend,api,node,rpc=warn
+ENV CHAIN_ID=31337
+ENTRYPOINT ["/usr/bin/bash", "-c"]
+CMD ["anvil", "--host 0.0.0.0", "--chain-id $CHAIN_ID"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This repository contains modifications to `foundryup` made by [Thrackle](https:/
 
 When running `foundryup --version`, it will download versioned precompiled binaries from the [thrackle-io/foundry](https://github.com/thrackle-io/foundry) repository.
 
+## Dockerfile
+
+This repo also includes a `Dockerfile` which builds a container with the stock Foundry CLI tools, 
+for use in local development and continuous integration testing.
+
+`foundry.lock` sets the version from [Releases](https://github.com/thrackle-io/foundry/releases) to use.
+
+`foundry.toml` provides basic per-environemnt Foundry configurations. See [Configuration](#configuration) below for details.
+
 ## Foundry
 <img src="https://github.com/foundry-rs/foundry/blob/master/.github/logo.png" alt="Foundry logo" align="right" width="120" />
 

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,3 @@
+# Pins a Foundry version (via commit hash), until they provide versions: https://github.com/foundry-rs/foundry/issues/3895
+# https://github.com/thrackle-io/foundry/releases/tag/v0.2.0
+v0.2.0

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,16 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+fs_permissions = [{ access = "read", path = "./out"}]
+gas_limit = "18446744073709551615"
+
+[profile.local]
+eth-rpc-url = 'http://localhost:8545'
+fs_permissions = [{ access = "read", path = "./out"}]
+
+[profile.docker]
+eth-rpc-url = 'http://anvil:8545'
+fs_permissions = [{ access = "read", path = "./out"}]
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
This allows other Thrackle microservices, such as indexer to run PR-checks using a stock Anvil container as part of their build. This eliminates the need of using other projects with unnecessary contracts.