### PR TITLE
Fix Dockerfile ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ FROM foundry-base AS anvil
 ENV FOUNDRY_PROFILE=docker
 ENV RUST_LOG=backend,api,node,rpc=warn
 ENV CHAIN_ID=31337
-ENTRYPOINT ["/usr/bin/bash", "-c"]
-CMD ["anvil", "--host 0.0.0.0", "--chain-id $CHAIN_ID"]
+
+# Note, Anvil does not correctly load args if used as a CMD, so use ENTRYPOINT
+ENTRYPOINT anvil --host 0.0.0.0 --chain-id "$CHAIN_ID"


### PR DESCRIPTION
The old version was ignoring args, causing it to listen only to 127.0.0.1